### PR TITLE
Bring fork up-to-date and fix method-override issue

### DIFF
--- a/elasticsearch-model/lib/elasticsearch/model.rb
+++ b/elasticsearch-model/lib/elasticsearch/model.rb
@@ -112,7 +112,7 @@ module Elasticsearch
         # Delegate common methods to the `__elasticsearch__` ClassMethodsProxy, unless they are defined already
         class << self
           METHODS.each do |method|
-            delegate method, to: :__elasticsearch__ unless self.respond_to?(method)
+            delegate method, to: :__elasticsearch__ unless self.public_instance_methods.include?(method)
           end
         end
       end

--- a/elasticsearch-model/lib/elasticsearch/model/version.rb
+++ b/elasticsearch-model/lib/elasticsearch/model/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module Model
-    VERSION = "7.1.0"
+    VERSION = "7.1.0.skroutz1"
   end
 end

--- a/elasticsearch-model/spec/elasticsearch/model/module_spec.rb
+++ b/elasticsearch-model/spec/elasticsearch/model/module_spec.rb
@@ -48,6 +48,7 @@ describe Elasticsearch::Model do
       end
 
       DummyIncludingModel.__send__ :include, Elasticsearch::Model
+      DummyIncludingModelWithSearchMethodDefined.__send__ :include, Elasticsearch::Model
     end
 
     after(:all) do


### PR DESCRIPTION
This PR is a "hard reset" on the tag `v7.1.0` which is our current bundled version
plus
two more commits that fix https://github.com/elastic/elasticsearch-rails/issues/924